### PR TITLE
Add MPS backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,17 @@ For more detaila about voice quality, check this document: [Kokoro-82M voices](h
 
 ## How to run on GPU
 
-By default, audiblez runs on CPU. If you pass the option `--cuda` it will try to use the Cuda device via Torch.
+By default, audiblez runs on CPU. You can use `--cuda` to run on a CUDA capable GPU,
+or `--mps` on Apple Silicon. When using MPS you may need to set
+`PYTORCH_ENABLE_MPS_FALLBACK=1`.
 
 Check out this example: [Audiblez running on a Google Colab Notebook with Cuda ](https://colab.research.google.com/drive/164PQLowogprWQpRjKk33e-8IORAvqXKI?usp=sharing]).
 
-We don't currently support Apple Silicon, as there is not yet a Kokoro implementation in MLX. As soon as it will be available, we will support it.
+Example command for MPS:
+
+```bash
+PYTORCH_ENABLE_MPS_FALLBACK=1 audiblez book.epub --mps
+```
 
 ## Manually pick chapters to convert
 
@@ -126,7 +132,7 @@ To do so, you can use `--pick` to interactively choose the chapters to convert (
 For all the options available, you can check the help page `audiblez --help`:
 
 ```
-usage: audiblez [-h] [-v VOICE] [-p] [-s SPEED] [-c] [-o FOLDER] epub_file_path
+usage: audiblez [-h] [-v VOICE] [-p] [-s SPEED] [-c] [-m] [-o FOLDER] epub_file_path
 
 positional arguments:
   epub_file_path        Path to the epub file
@@ -139,11 +145,13 @@ options:
   -s SPEED, --speed SPEED
                         Set speed from 0.5 to 2.0
   -c, --cuda            Use GPU via Cuda in Torch if available
+  -m, --mps             Use Apple MPS backend in Torch if available
   -o FOLDER, --output FOLDER
                         Output folder for the audiobook and temporary files
 
 example:
-  audiblez book.epub -l en-us -v af_sky
+  audiblez book.epub -l en-us -v af_sky --cuda
+  audiblez book.epub -l en-us -v af_sky --mps
 
 to use the GUI, run:
   audiblez-ui

--- a/audiblez/cli.py
+++ b/audiblez/cli.py
@@ -8,7 +8,8 @@ from audiblez.voices import voices, available_voices_str
 def cli_main():
     voices_str = ', '.join(voices)
     epilog = ('example:\n' +
-              '  audiblez book.epub -l en-us -v af_sky\n\n' +
+              '  audiblez book.epub -l en-us -v af_sky --cuda\n' +
+              '  audiblez book.epub -l en-us -v af_sky --mps\n\n' +
               'to run GUI just run:\n'
               '  audiblez-ui\n\n' +
               'available voices:\n' +
@@ -20,6 +21,7 @@ def cli_main():
     parser.add_argument('-p', '--pick', default=False, help=f'Interactively select which chapters to read in the audiobook', action='store_true')
     parser.add_argument('-s', '--speed', default=1.0, help=f'Set speed from 0.5 to 2.0', type=float)
     parser.add_argument('-c', '--cuda', default=False, help=f'Use GPU via Cuda in Torch if available', action='store_true')
+    parser.add_argument('-m', '--mps', default=False, help='Use Apple MPS backend in Torch if available', action='store_true')
     parser.add_argument('-o', '--output', default='.', help='Output folder for the audiobook and temporary files', metavar='FOLDER')
 
     if len(sys.argv) == 1:
@@ -34,6 +36,14 @@ def cli_main():
             torch.set_default_device('cuda')
         else:
             print('CUDA GPU not available. Defaulting to CPU')
+
+    if args.mps:
+        import torch
+        if torch.backends.mps.is_available():
+            print('Apple MPS device available')
+            torch.set_default_device('mps')
+        else:
+            print('Apple MPS not available. Defaulting to CPU')
 
     from core import main
     main(args.epub_file_path, args.voice, args.pick, args.speed, args.output)

--- a/audiblez/ui.py
+++ b/audiblez/ui.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # A simple wxWidgets UI for audiblez
 
-import torch.cuda
+import torch
 import numpy as np
 import soundfile
 import threading
@@ -273,8 +273,11 @@ class MainWindow(wx.Frame):
         engine_radio_panel = wx.Panel(panel)
         cpu_radio = wx.RadioButton(engine_radio_panel, label="CPU", style=wx.RB_GROUP)
         cuda_radio = wx.RadioButton(engine_radio_panel, label="CUDA")
+        mps_radio = wx.RadioButton(engine_radio_panel, label="MPS")
         if torch.cuda.is_available():
             cuda_radio.SetValue(True)
+        elif torch.backends.mps.is_available():
+            mps_radio.SetValue(True)
         else:
             cpu_radio.SetValue(True)
             # cuda_radio.Disable()
@@ -284,8 +287,10 @@ class MainWindow(wx.Frame):
         engine_radio_panel.SetSizer(engine_radio_panel_sizer)
         engine_radio_panel_sizer.Add(cpu_radio, 0, wx.ALL, 5)
         engine_radio_panel_sizer.Add(cuda_radio, 0, wx.ALL, 5)
+        engine_radio_panel_sizer.Add(mps_radio, 0, wx.ALL, 5)
         cpu_radio.Bind(wx.EVT_RADIOBUTTON, lambda event: torch.set_default_device('cpu'))
         cuda_radio.Bind(wx.EVT_RADIOBUTTON, lambda event: torch.set_default_device('cuda'))
+        mps_radio.Bind(wx.EVT_RADIOBUTTON, lambda event: torch.set_default_device('mps'))
 
         # Create a list of voices with flags
         flag_and_voice_list = []


### PR DESCRIPTION
## Summary
- add `--mps` CLI option with runtime check
- show CUDA and MPS examples in CLI help
- add MPS radio button in the GUI and default to MPS when available
- document MPS usage in README

## Testing
- `pip install -e .` *(fails: large output)*
- `pytest -q` *(fails: FileNotFoundError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68465d6abf3c832f85ee4ec9accbf247